### PR TITLE
Fixes oc command to use shell script instead of alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,11 +111,16 @@ RUN cat ./image-message >> ./.bashrc-ni
 
 RUN curl -L https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz --output oc-client.tar.gz && \
     tar xzf oc-client.tar.gz && \
-    sudo cp openshift-origin-client-tools*/oc /usr/local/bin && \
-    sudo chmod +x /usr/local/bin/oc && \
+    sudo mkdir -p /usr/local/fix && \
+    sudo chmod a+rwx /usr/local/fix && \
+    sudo cp openshift-origin-client-tools*/oc /usr/local/fix && \
+    sudo chmod +x /usr/local/fix/oc && \
     rm -rf openshift-origin-client-tools* && \
     rm oc-client.tar.gz && \
-    echo "alias oc='/lib/ld-musl-x86_64.so.1 --library-path /lib /usr/local/bin/oc'" >> ./.bashrc-ni
+    echo '/lib/ld-musl-x86_64.so.1 --library-path /lib /usr/local/fix/oc $@' > ./oc && \
+    sudo mv ./oc /usr/local/bin && \
+    sudo chmod +x /usr/local/bin/oc
+#    echo "alias oc='/lib/ld-musl-x86_64.so.1 --library-path /lib /usr/local/bin/oc'" >> ./.bashrc-ni
 
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \

--- a/config.yaml
+++ b/config.yaml
@@ -49,10 +49,10 @@ commandTests:
     args: ["--help"]
     expectedOutput: ["usage: git.*"]
 
-#  - name: "OpenShift client installation"
-#    command: "/lib/ld-musl-x86_64.so.1 --library-path /lib /usr/local/bin/oc"
-#    args: ["--help"]
-#    expectedOutput: [".*OpenShift.*"]
+  - name: "OpenShift client installation"
+    command: "oc"
+    args: ["--help"]
+    expectedOutput: [".*OpenShift.*"]
 
 fileExistenceTests:
   - name: 'jenkins-config-template.xml'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tools",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "org": "ibmgaragecloud",
   "branch": "lite",
   "description": "This repository contains a docker image to help setup an IBM Cloud Public development environment.",


### PR DESCRIPTION
On Alpine the glibc library is different requiring extra config for it to run. Previously we used an alias set in the .bash-ni to configure the library but that is dependent on the bash-ni file being sourced.

This change puts the logic in a shell in /usr/local/bin/oc and moves the oc command into /usr/local/fix